### PR TITLE
add numpy

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ lint =
     flake8==3.9.2
     isort==5.8.0
 dev =
+    numpy
     pre-commit
     pytest
 release =


### PR DESCRIPTION
This PR adds `numpy` dependency to the `setup.cfg` for PyPI.